### PR TITLE
Ignore EOF in NumberObject.read_from_stream

### DIFF
--- a/PyPDF2/generic/_base.py
+++ b/PyPDF2/generic/_base.py
@@ -402,7 +402,7 @@ class NumberObject(int, PdfObject):
 
     @staticmethod
     def read_from_stream(stream: StreamType) -> Union["NumberObject", "FloatObject"]:
-        num = read_until_regex(stream, NumberObject.NumberPattern)
+        num = read_until_regex(stream, NumberObject.NumberPattern, ignore_eof=True)
         if num.find(b".") != -1:
             return FloatObject(num)
         return NumberObject(num)


### PR DESCRIPTION
Use `ignore_eof=True` just like `NameObject` does, which is the only other caller to `read_until_regex` in this module.

This helps prevent arcane exceptions when trying to parse a number:

```
PyPDF2.errors.PdfStreamError: Stream has ended unexpectedly
```

The motivation is essentially identical to the change that introduced `ignore_eof=True` on `NameObject`s:
https://github.com/py-pdf/PyPDF2/commit/431ba7092037af7d1c296f8f280aca167859ce61